### PR TITLE
Protect getSettings from picking up empty assignments

### DIFF
--- a/fix/utils.go
+++ b/fix/utils.go
@@ -102,7 +102,9 @@ func getSetting(s string, key ...string) (v string, ok bool) {
 			}
 			prefix := "; " + p + " ="
 			if strings.HasPrefix(s, prefix) {
-				return strings.TrimSpace(s[len(prefix):]), true
+				if v := strings.TrimSpace(s[len(prefix):]); v != "" {
+					return v, true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There are cases where (for whatever reason) PrusaSlicer emits a variable definition at the end with an empty value. For example, in my case it was emitting:

   ; printer_model = 

This line, when processed via `getSettings()`, results in `"", true`. Notice the `true` at the end. It thinks this is a legitimate value when in reality it's just empty.

The problem is that when one tries to "overwrite" this in PrusaSlicer, you can only put custom G-code _before_ the variables dump at the end.
```
; printer_model = J1  <--- this is emitted by my custom "End g-code"
.... lots of lines of g-code...
; printer_model =      <---- this is emitted by PrusaSlicer
```

 Therefore, no matter what you do, as long as getSettings() returns a `true`, the value that we emit gets overwritten by an empty string, and in my case it results in a "invalid G-code"
